### PR TITLE
systemctl prints ● instead of * in C.UTF-8 locale

### DIFF
--- a/checks/systemd_units
+++ b/checks/systemd_units
@@ -86,7 +86,7 @@ def parse_systemd_units(info):
             "UnitEntry", ['name', 'type', 'load', 'active', 'sub', 'description', 'state'])
 
         for row in iter_info:
-            if row[0] == '*':
+            if row[0] in {'●', '*'}:
                 row.pop(0)
             line = ' '.join(row)
             for unit_marker in _SYSTEMD_UNITS:


### PR DESCRIPTION
New version of checkmk doesn't correctly detects failed systemd units. 
The reason is parser, which expects this syntax for broken units `* syslog.target not-found inactive dead syslog.target
`.
But in C.UTF-8 locale (which explicitly set by agent) command `systemctl --all --no-pager` prints `● syslog.target not-found inactive dead syslog.target`.

This PR fixes parser and it can understand both type of outputs.

Another way to fix it - run `LC_ALL=C systemctl --all --no-pager` command, with explicit redefine of LC_ALL for systemctl. I'm not sure what way of fix do you prefer, but please, fix the issue.

It was already reported on forum https://forum.checkmk.com/t/regarding-systemd-service-summary/23755